### PR TITLE
Update multipass cloud-init url

### DIFF
--- a/page/docs/environment/env.md
+++ b/page/docs/environment/env.md
@@ -70,7 +70,7 @@ There is always the option to use the multipass configuration if the Docker imag
 Multipass creates a virtual machine with Direktiv pre-configured. The configuration is different from the Docker image but all features are available to that approach as well. The cloud-init script will do the configuration during first boot and takes a few minutes to complete. Eventing is anebled by default.
 
 ```sh title="Start Multipass Instance"
-multipass launch --cpus 4 --disk 20G --memory 6G --name direktiv --cloud-init https://raw.githubusercontent.com/direktiv/direktiv/main/build/docker/all/multipass/init.yaml
+multipass launch --cpus 4 --disk 20G --memory 6G --name direktiv --cloud-init https://raw.githubusercontent.com/direktiv/direktiv/main/scripts/build/docker/all/multipass/init.yaml
 ```
 
 After startup the machine can be access with a simple command. For convenience there is a `kubectl` shortcut and code completion installed. 
@@ -109,7 +109,7 @@ Enabling a proxy has to be done by changing the cloud-init file manually. The fi
 
 
 ```sh title="Download Cloud-Init"
-curl https://raw.githubusercontent.com/direktiv/direktiv/main/build/docker/all/multipass/init.yaml > myinit.yaml
+curl https://raw.githubusercontent.com/direktiv/direktiv/main/scripts/build/docker/all/multipass/init.yaml > myinit.yaml
 ```
 
 The proxy configuration values need to be added as a file under `/env`. The following snippet is an example for such a configuration.


### PR DESCRIPTION
## Description

The multipass cloud-init url has changed.  The new url is:
https://raw.githubusercontent.com/direktiv/direktiv/main/scripts/build/docker/all/multipass/init.yaml

## Purpose

- [x] Bug fix
- [ ] New feature
- [ ] Other

## How was this tested? (if applicable)
NA

## Test Platform Details (if applicable)

## Checklist

- [ ] Code is commented
- [ ] Unit test coverage encompasses new code
- [ ] Existing unit tests pass with these changes
- [ ] PR is signed
